### PR TITLE
Fix/Joint Command Interfaces

### DIFF
--- a/flexiv_bringup/config/rizon_controllers.yaml
+++ b/flexiv_bringup/config/rizon_controllers.yaml
@@ -22,6 +22,7 @@ position_joint_trajectory_controller:
   joints: *robot_joints
   constraints:
     goal_time: 0.5
+    stopped_velocity_tolerance: 0.01
     joint1: { goal: 0.05}
     joint2: { goal: 0.05}
     joint3: { goal: 0.05}

--- a/flexiv_bringup/config/rizon_controllers.yaml
+++ b/flexiv_bringup/config/rizon_controllers.yaml
@@ -22,7 +22,6 @@ position_joint_trajectory_controller:
   joints: *robot_joints
   constraints:
     goal_time: 0.5
-    stopped_velocity_tolerance: 0.05
     joint1: { goal: 0.05}
     joint2: { goal: 0.05}
     joint3: { goal: 0.05}
@@ -30,56 +29,6 @@ position_joint_trajectory_controller:
     joint5: { goal: 0.05}
     joint6: { goal: 0.05}
     joint7: { goal: 0.05}
-  stop_trajectory_duration: 0.5
-  state_publish_rate: 100.0
-  action_monitor_rate: 20.0
-
-velocity_joint_trajectory_controller:
-  type: velocity_controllers/JointTrajectoryController
-  joints: *robot_joints
-  constraints:
-    goal_time: 0.5
-    stopped_velocity_tolerance: 0.05
-    joint1: { goal: 0.05}
-    joint2: { goal: 0.05}
-    joint3: { goal: 0.05}
-    joint4: { goal: 0.05}
-    joint5: { goal: 0.05}
-    joint6: { goal: 0.05}
-    joint7: { goal: 0.05}
-  gains:
-    joint1: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-    joint2: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-    joint3: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-    joint4: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-    joint5: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-    joint6: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-    joint7: {p: 5.0, i: 0.05, d: 0.1, i_clamp: 1}
-  stop_trajectory_duration: 0.5
-  state_publish_rate: 100.0
-  action_monitor_rate: 20.0
-
-effort_joint_trajectory_controller:
-  type: effort_controllers/JointTrajectoryController
-  joints: *robot_joints
-  constraints:
-    goal_time: 0.5
-    stopped_velocity_tolerance: 0.05
-    joint1: { goal: 0.05}
-    joint2: { goal: 0.05}
-    joint3: { goal: 0.05}
-    joint4: { goal: 0.05}
-    joint5: { goal: 0.05}
-    joint6: { goal: 0.05}
-    joint7: { goal: 0.05}
-  gains:
-    joint1: { p: 3000, d: 80, i: 0 }
-    joint2: { p: 3000, d: 80, i: 0 }
-    joint3: { p: 800, d: 40, i: 0 }
-    joint4: { p: 800, d: 40, i: 0 }
-    joint5: { p: 200, d: 8, i: 0 }
-    joint6: { p: 200, d: 8, i: 0 }
-    joint7: { p: 200, d: 8, i: 0 }
   stop_trajectory_duration: 0.5
   state_publish_rate: 100.0
   action_monitor_rate: 20.0

--- a/flexiv_hardware/include/flexiv_hardware/flexiv_hardware_interface.h
+++ b/flexiv_hardware/include/flexiv_hardware/flexiv_hardware_interface.h
@@ -131,6 +131,27 @@ protected:
     virtual bool initRobot();
 
     /**
+     * @brief Get current joint position and set the joint command with those
+     * values.
+     */
+    virtual void setInitPosition();
+
+    /**
+     * @brief Checks whether a vector of doubles contains NaN values.
+     * @param[in] vector The vector to check.
+     * @return True if the vector contains NaN values, false otherwise.
+     */
+    static bool vectorHasNan(const std::vector<double>& vector)
+    {
+        for (const double& value : vector) {
+            if (std::isnan(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @brief Configures a limit interface to enforce limits on effort, velocity
      * or position level on joint commands.
      * @param[in] limits_interface Limit interface for the robot.
@@ -231,10 +252,10 @@ protected:
     std::vector<double> internal_joint_position_command_;
 
     // Controller
-    bool position_controller_running_;
-    bool velocity_controller_running_;
-    bool effort_controller_running_;
-    bool controllers_initialized_;
+    std::atomic<bool> position_controller_running_;
+    std::atomic<bool> velocity_controller_running_;
+    std::atomic<bool> effort_controller_running_;
+    std::atomic<bool> controllers_initialized_;
 
     // Publisher
     std::unique_ptr<

--- a/flexiv_hardware/include/flexiv_hardware/flexiv_hardware_interface.h
+++ b/flexiv_hardware/include/flexiv_hardware/flexiv_hardware_interface.h
@@ -38,7 +38,6 @@ class FlexivHardwareInterface : public hardware_interface::RobotHW
 public:
     /**
      * @brief Construct a new FlexivHardwareInterface object
-     *
      */
     FlexivHardwareInterface();
 
@@ -48,7 +47,6 @@ public:
      * @brief Handles the setup functionality for the ROS interface. This
      * includes parsing ROS parameters, connecting to the robot, and setting up
      * hardware interfaces for ros_control.
-     *
      * @param[in] root_nh Root level ROS node handle.
      * @param[in] robot_hw_nh ROS node handle for the robot namespace.
      * @return True if successful, false otherwise.
@@ -59,7 +57,6 @@ public:
     /**
      * @brief Reads the parameterization of the hardware class from the ROS
      * parameter server (e.g. local_ip, robot_ip, joint_names etc.)
-     *
      * @param[in] root_nh A node handle in the root namespace of the control
      * node.
      * @param[in] robot_hw_nh A node handle in the namespace of the robot
@@ -71,7 +68,6 @@ public:
 
     /**
      * @brief Initializes the class in terms of ros_control interfaces.
-     *
      * @note You have to call initParameters beforehand. Use the complete
      * initialization routine \ref init() method to control robots.
      * @param[in] robot_hw_nh A node handle in the namespace of the robot
@@ -81,7 +77,6 @@ public:
 
     /**
      * @brief Reads data from the robot.
-     *
      * @param[in] time Current time.
      * @param[in] period Duration of current control loop iteration.
      */
@@ -90,7 +85,6 @@ public:
 
     /**
      * @brief Writes data to the robot.
-     *
      * @param[in] time Current time.
      * @param[in] period Duration of current control loop iteration.
      */
@@ -99,13 +93,11 @@ public:
 
     /**
      * @brief Set all members to default values.
-     *
      */
     virtual void reset();
 
     /**
      * @brief Prepares switching between controllers.
-     *
      * @param[in] start_list List of requested controllers to start.
      * @param[in] stop_list List of requested controllers to stop.
      * @return True if the preparation has been successful, false otherwise.
@@ -117,7 +109,6 @@ public:
 
     /**
      * @brief Perform controllers switching.
-     *
      * @param[in] start_list List of requested controllers to start.
      * @param[in] stop_list List of requested controllers to stop.
      */
@@ -126,8 +117,8 @@ public:
         const std::list<hardware_interface::ControllerInfo>& stop_list)
         override;
 
-    /** @brief Enforce limits on position, velocity, and effort.
-     *
+    /**
+     * @brief Enforce limits on position, velocity, and effort.
      * @param[in] period The duration of the current cycle.
      */
     virtual void enforceLimits(const ros::Duration& period);
@@ -135,22 +126,13 @@ public:
 protected:
     /**
      * @brief Uses the robot_ip to connect to the robot via RDK.
-     *
      * @return True if successful, false otherwise.
      */
     virtual bool initRobot();
 
     /**
-     * @brief Get current joint position and set the joint command with those
-     * values.
-     *
-     */
-    virtual void setInitPosition();
-
-    /**
      * @brief Configures a limit interface to enforce limits on effort, velocity
      * or position level on joint commands.
-     *
      * @param[in] limits_interface Limit interface for the robot.
      * @param[in] command_interface  Command interface to match with the limit
      * interface.
@@ -198,7 +180,6 @@ protected:
     /**
      * @brief Checks whether a resource list contains joints from this hardware
      * interface.
-     *
      * @param[in] claimed_resources List of claimed resources.
      * @return True if the list contains joints from this hardware interface,
      * false otherwise.
@@ -209,7 +190,6 @@ protected:
     /**
      * @brief Publishes external force applied on TCP in TCP frame \f$
      * ^{TCP}F_{ext}~[N][Nm] \f$ and base frame \f$ ^{0}F_{ext}~[N][Nm] \f$.
-     *
      */
     virtual void publishExternalForce();
 
@@ -239,6 +219,7 @@ protected:
     std::vector<double> joint_position_state_;
     std::vector<double> joint_velocity_state_;
     std::vector<double> joint_effort_state_;
+
     // External force
     std::vector<double> ext_force_in_tcp_;
     std::vector<double> ext_force_in_base_;

--- a/flexiv_hardware/src/flexiv_hardware_interface_node.cpp
+++ b/flexiv_hardware/src/flexiv_hardware_interface_node.cpp
@@ -35,6 +35,7 @@ int main(int argc, char** argv)
         ROS_ERROR("Failed to initialize Flexiv Hardware Interface.");
         exit(1);
     }
+
     // Create the controller manager
     controller_manager::ControllerManager cm(
         flexiv_hardware_interface.get(), nh);


### PR DESCRIPTION
The default velocity and effort joint trajectory controller from [ros_controllers](https://github.com/ros-controls/ros_controllers) did not work effectively with the joint command interfaces in the Flexiv hardware interface. 

- Remove velocity and effort joint trajectory controller from the config file
- Update the controllers / control mode switching in the hardware interface